### PR TITLE
Fix MMCE Art Loading Issues and UI Stalls

### DIFF
--- a/include/texcache.h
+++ b/include/texcache.h
@@ -72,9 +72,6 @@ void cacheCancelPendingImageLoads(void);
  */
 int cacheCancelPendingImageLoadsTimed(int timeoutTicks);
 
-/** Cancels queued MMCE-backed interactive art and waits up to timeoutTicks for active MMCE art to drain.
- */
-int cacheAbortMmceImageLoadsTimed(int timeoutTicks);
 
 /** Invalidates queued art loads without blocking on the IO worker.
  */

--- a/include/texcache.h
+++ b/include/texcache.h
@@ -72,7 +72,6 @@ void cacheCancelPendingImageLoads(void);
  */
 int cacheCancelPendingImageLoadsTimed(int timeoutTicks);
 
-
 /** Invalidates queued art loads without blocking on the IO worker.
  */
 void cacheAdvanceGeneration(void);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -81,8 +81,7 @@ static s32 menuSemaId;
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
-#define MENU_MMCE_ART_ABORT_WAIT_TICKS 60
-#define MENU_MMCE_CONFIG_IDLE_FRAMES   20
+#define MENU_MMCE_CONFIG_IDLE_FRAMES 20
 
 static void menuInvalidateArtSelection(void)
 {
@@ -268,13 +267,7 @@ static config_set_t *menuLoadConfigDirectInternal(void)
     if (result != NULL || list == NULL || configId < 0)
         return result;
 
-    if (list->mode == MMCE_MODE) {
-        if (!cacheAbortMmceImageLoadsTimed(MENU_MMCE_ART_ABORT_WAIT_TICKS)) {
-            cacheEnd(1);
-            cacheInit();
-        }
-    } else
-        (void)cacheCancelPendingImageLoadsTimed(MENU_MIN_INACTIVE_FRAMES);
+    (void)cacheCancelPendingImageLoadsTimed(MENU_MIN_INACTIVE_FRAMES);
     loadedConfig = list->itemGetConfig(list, configId);
 
     WaitSema(menuSemaId);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -81,7 +81,7 @@ static s32 menuSemaId;
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
-#define MENU_MMCE_CONFIG_IDLE_FRAMES 20
+#define MENU_MMCE_CONFIG_IDLE_FRAMES   20
 
 static void menuInvalidateArtSelection(void)
 {

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -81,7 +81,7 @@ static s32 menuSemaId;
 static s32 menuListSemaId = -1;
 static ee_sema_t menuSema;
 
-#define MENU_MMCE_CONFIG_IDLE_FRAMES   20
+#define MENU_MMCE_CONFIG_IDLE_FRAMES 20
 
 static void menuInvalidateArtSelection(void)
 {

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -192,7 +192,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     int result = 0;
     struct stat st;
 
-    //Hacky: check if slot was changed, update prefix if needed
+    // Hacky: check if slot was changed, update prefix if needed
     mmceSetPrefix();
 
     if (mmcePrefix[0] == '\0') {
@@ -412,7 +412,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         strcpy(filename, game->startup);
 
 
-    //MMCEDRV settings
+    // MMCEDRV settings
     if (gMMCESlot == 0)
         settings->port = 2;
     else if (gMMCESlot == 1)
@@ -429,8 +429,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     settings->ack_wait_cycles = gMMCEAckWaitCycles;
     settings->use_alarms = gMMCEUseAlarms;
 
-    //TEMP: The fd given by sd2psx is not the same one we see here on the EE
-    //and ps2sdk_get_iop_fd does not seem to return the right value either
+    // TEMP: The fd given by sd2psx is not the same one we see here on the EE
+    // and ps2sdk_get_iop_fd does not seem to return the right value either
     settings->iso_fd = fileXioIoctl2(iso_file, 0x80, NULL, 0, NULL, 0);
 
     LOG("name: %s\n", game->name);
@@ -458,8 +458,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
     }
 
-    //mcReset();
-    //mcInit(MC_TYPE_XMC);
+    // mcReset();
+    // mcInit(MC_TYPE_XMC);
 
     if (gAutoLaunchBDMGame == NULL) {
         deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
@@ -534,7 +534,7 @@ static void mmceShutdown(item_list_t *itemList)
     }
 
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
-    //fileXioDevctl("mass:", USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    // fileXioDevctl("mass:", USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
 }
 
 static int mmceCheckVMC(item_list_t *itemList, char *name, int createSize)
@@ -555,7 +555,7 @@ static item_list_t mmceGameList = {
 void mmceInitSemaphore()
 {
     // Create a semaphore so only one thread can load IOP modules at a time.
-    //if (mmceLoadModuleLock < 0) {
+    // if (mmceLoadModuleLock < 0) {
     //    mmceLoadModuleLock = sbCreateSemaphore();
     //}
 }

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -29,7 +29,7 @@ static time_t mmceModifiedDVDPrev;
 static int mmceGameCount = 0;
 static base_game_info_t *mmceGames;
 
-#define MMCE_GAMEID_WAIT_TICKS    120
+#define MMCE_GAMEID_WAIT_TICKS 120
 
 // forward declaration
 static item_list_t mmceGameList;

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -30,7 +30,6 @@ static int mmceGameCount = 0;
 static base_game_info_t *mmceGames;
 
 #define MMCE_GAMEID_WAIT_TICKS    120
-#define MMCE_ART_ABORT_WAIT_TICKS 60
 
 // forward declaration
 static item_list_t mmceGameList;
@@ -310,11 +309,6 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         game = &mmceGames[id];
     else
         game = gAutoLaunchBDMGame;
-
-    if (!cacheAbortMmceImageLoadsTimed(MMCE_ART_ABORT_WAIT_TICKS)) {
-        cacheEnd(1);
-        cacheInit();
-    }
 
     void *irx = &mmce_cdvdman_irx;
     int irx_size = size_mmce_cdvdman_irx;

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -29,7 +29,7 @@ static time_t mmceModifiedDVDPrev;
 static int mmceGameCount = 0;
 static base_game_info_t *mmceGames;
 
-#define MMCE_GAMEID_WAIT_TICKS 120
+#define MMCE_GAMEID_WAIT_TICKS    120
 
 // forward declaration
 static item_list_t mmceGameList;
@@ -192,7 +192,7 @@ static int mmceNeedsUpdate(item_list_t *itemList)
     int result = 0;
     struct stat st;
 
-    // Hacky: check if slot was changed, update prefix if needed
+    //Hacky: check if slot was changed, update prefix if needed
     mmceSetPrefix();
 
     if (mmcePrefix[0] == '\0') {
@@ -412,7 +412,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         strcpy(filename, game->startup);
 
 
-    // MMCEDRV settings
+    //MMCEDRV settings
     if (gMMCESlot == 0)
         settings->port = 2;
     else if (gMMCESlot == 1)
@@ -429,8 +429,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     settings->ack_wait_cycles = gMMCEAckWaitCycles;
     settings->use_alarms = gMMCEUseAlarms;
 
-    // TEMP: The fd given by sd2psx is not the same one we see here on the EE
-    // and ps2sdk_get_iop_fd does not seem to return the right value either
+    //TEMP: The fd given by sd2psx is not the same one we see here on the EE
+    //and ps2sdk_get_iop_fd does not seem to return the right value either
     settings->iso_fd = fileXioIoctl2(iso_file, 0x80, NULL, 0, NULL, 0);
 
     LOG("name: %s\n", game->name);
@@ -458,8 +458,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
     }
 
-    // mcReset();
-    // mcInit(MC_TYPE_XMC);
+    //mcReset();
+    //mcInit(MC_TYPE_XMC);
 
     if (gAutoLaunchBDMGame == NULL) {
         deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
@@ -534,7 +534,7 @@ static void mmceShutdown(item_list_t *itemList)
     }
 
     // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
-    // fileXioDevctl("mass:", USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    //fileXioDevctl("mass:", USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
 }
 
 static int mmceCheckVMC(item_list_t *itemList, char *name, int createSize)
@@ -555,7 +555,7 @@ static item_list_t mmceGameList = {
 void mmceInitSemaphore()
 {
     // Create a semaphore so only one thread can load IOP modules at a time.
-    // if (mmceLoadModuleLock < 0) {
+    //if (mmceLoadModuleLock < 0) {
     //    mmceLoadModuleLock = sbCreateSemaphore();
     //}
 }

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -47,7 +47,6 @@ enum {
 };
 
 #define CACHE_SLOW_MODE_INTERACTIVE_DELAY 4
-#define CACHE_MMCE_INTERACTIVE_MAX_DELAY  12
 #define CACHE_APP_INTERACTIVE_MAX_DELAY   4
 #define CACHE_APP_PREFETCH_DELAY          10
 #define CACHE_PRIME_IDLE_DELAY            12
@@ -264,8 +263,7 @@ static int cacheGetPrefetchLimit(const image_cache_t *cache)
 
 static int cacheShouldPreferLoadedVictim(const image_cache_t *cache, unsigned char priority, int effectiveMode)
 {
-    return cache != NULL && priority == CACHE_REQ_PRIORITY_INTERACTIVE && effectiveMode == MMCE_MODE &&
-           cache->suffix != NULL && strcmp(cache->suffix, "COV") == 0;
+    return 0;
 }
 
 static int cacheGetEffectiveMode(const item_list_t *list, const char *value)
@@ -304,14 +302,11 @@ static int cacheGetInteractiveDelay(const item_list_t *list, const char *value)
             return 0;
     }
 
-    if ((mode == APP_MODE || mode == MMCE_MODE) && delay < CACHE_SLOW_MODE_INTERACTIVE_DELAY)
+    if (mode == APP_MODE && delay < CACHE_SLOW_MODE_INTERACTIVE_DELAY)
         delay = CACHE_SLOW_MODE_INTERACTIVE_DELAY;
 
     if (list != NULL && list->mode == APP_MODE && delay > CACHE_APP_INTERACTIVE_MAX_DELAY)
         delay = CACHE_APP_INTERACTIVE_MAX_DELAY;
-
-    if (mode == MMCE_MODE && delay > CACHE_MMCE_INTERACTIVE_MAX_DELAY)
-        delay = CACHE_MMCE_INTERACTIVE_MAX_DELAY;
 
     return delay;
 }
@@ -363,12 +358,12 @@ static load_image_request_t *cacheFindQueuedInteractiveModeLocked(int mode)
 
 static int cacheIsAbortableMmceRequest(load_image_request_t *req)
 {
-    return req != NULL && req->priority == CACHE_REQ_PRIORITY_INTERACTIVE && req->effectiveMode == MMCE_MODE;
+    return 0;
 }
 
 static int cacheShouldDiscardCompletedRequestLocked(load_image_request_t *req)
 {
-    return cacheIsAbortableMmceRequest(req) && req->generation != gCacheGeneration;
+    return 0;
 }
 
 static int cacheIsNavigationActive(void)
@@ -379,20 +374,12 @@ static int cacheIsNavigationActive(void)
 
 static int cacheShouldDeferInteractiveArtOnInput(const item_list_t *list, const char *value)
 {
-    int effectiveMode = cacheGetEffectiveMode(list, value);
-
-    if (list != NULL && list->mode == MMCE_MODE && effectiveMode == MMCE_MODE)
-        return cacheIsNavigationActive();
-
     return 0;
 }
 
 static int cacheGetLoadThreadPriority(const load_image_request_t *req)
 {
     if (req != NULL && req->list != NULL) {
-        if (req->list->mode == MMCE_MODE && req->effectiveMode == MMCE_MODE)
-            return 90;
-
         if (req->list->mode == APP_MODE)
             return 0x38;
     }
@@ -1037,40 +1024,6 @@ int cacheCancelPendingImageLoadsTimed(int timeoutTicks)
     return cacheWaitForAllRequestsTimed(timeoutTicks);
 }
 
-int cacheAbortMmceImageLoadsTimed(int timeoutTicks)
-{
-    cacheLock();
-
-    if (gArtCurrentReq != NULL && cacheIsAbortableMmceRequest(gArtCurrentReq))
-        gArtCurrentReq->abortRequested = 1;
-
-    for (load_image_request_t *req = gArtInteractiveReqList, *next; req != NULL; req = next) {
-        next = req->next;
-        if (req->effectiveMode == MMCE_MODE)
-            cacheDropQueuedRequestLocked(req);
-    }
-
-    cacheUnlock();
-
-    cacheWakeWorker();
-
-    while (timeoutTicks != 0) {
-        int pending;
-
-        cacheLock();
-        pending = cacheHasActiveInteractiveModeLocked(MMCE_MODE) || cacheHasQueuedInteractiveModeLocked(MMCE_MODE);
-        cacheUnlock();
-
-        if (!pending)
-            return 1;
-
-        delay(1);
-        if (timeoutTicks > 0)
-            timeoutTicks--;
-    }
-
-    return 0;
-}
 
 void cacheAdvanceGeneration(void)
 {
@@ -1303,7 +1256,7 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
             return NULL;
         }
     } else {
-        if (list == NULL || effectiveMode == MMCE_MODE || guiInactiveFrames < cacheGetPrefetchDelay(list, value)) {
+        if (list == NULL || guiInactiveFrames < cacheGetPrefetchDelay(list, value)) {
             cacheUnlock();
             return NULL;
         }
@@ -1338,17 +1291,6 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
         return NULL;
     }
 
-    if (priority == CACHE_REQ_PRIORITY_INTERACTIVE && list != NULL && list->mode == MMCE_MODE && effectiveMode == MMCE_MODE) {
-        load_image_request_t *queuedMmceReq = cacheFindQueuedInteractiveModeLocked(MMCE_MODE);
-
-        if (queuedMmceReq != NULL && (queuedMmceReq->cache != cache || strcmp(queuedMmceReq->value, value) != 0))
-            cacheDropQueuedRequestLocked(queuedMmceReq);
-
-        if (cacheHasActiveInteractiveModeLocked(MMCE_MODE) || cacheHasQueuedInteractiveModeLocked(MMCE_MODE)) {
-            cacheUnlock();
-            return NULL;
-        }
-    }
 
     if (priority == CACHE_REQ_PRIORITY_PREFETCH && cache->queuedPrefetchRequests >= cacheGetPrefetchLimit(cache)) {
         cacheUnlock();

--- a/src/texcache.c
+++ b/src/texcache.c
@@ -1024,7 +1024,6 @@ int cacheCancelPendingImageLoadsTimed(int timeoutTicks)
     return cacheWaitForAllRequestsTimed(timeoutTicks);
 }
 
-
 void cacheAdvanceGeneration(void)
 {
     cacheLock();
@@ -1290,7 +1289,6 @@ static GSTEXTURE *cacheGetTextureInternal(image_cache_t *cache, item_list_t *lis
         cacheUnlock();
         return NULL;
     }
-
 
     if (priority == CACHE_REQ_PRIORITY_PREFETCH && cache->queuedPrefetchRequests >= cacheGetPrefetchLimit(cache)) {
         cacheUnlock();

--- a/src/textures.c
+++ b/src/textures.c
@@ -358,7 +358,7 @@ static void texReadFileFunction(png_structp pngPtr, png_bytep data, png_size_t l
 
 static int texShouldUseMemoryReader(const char *filePath)
 {
-    return filePath != NULL && (!strncmp(filePath, "mmce0:", 6) || !strncmp(filePath, "mmce1:", 6));
+    return 0;
 }
 
 static int texStageExternalFileIntoMemory(int fd, void **buffer)


### PR DESCRIPTION
This PR removes all arbitrary deferrals, prefetch limiters, custom thread priorities, and abort timeouts that were exclusively hardcoded for `MMCE_MODE` art loading. By standardizing the cache logic to rely entirely on the base cache implementation used by USB (`BDM_MODE`), the MMCE device page art will now load consistently without stalling the UI or prematurely dumping cached UI assets upon input.

---
*PR created automatically by Jules for task [9713080117175009744](https://jules.google.com/task/9713080117175009744) started by @NathanNeurotic*